### PR TITLE
Refactor shift forms to react hook form with zod validation

### DIFF
--- a/components/cutting-section.tsx
+++ b/components/cutting-section.tsx
@@ -1,7 +1,12 @@
 "use client"
 
-import type React from "react"
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { AlertCircle, Settings, Scissors } from "lucide-react"
+import { useForm, type FieldErrors } from "react-hook-form"
+import { z } from "zod"
+
+import { FormFieldError } from "@/components/form-field-error"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -9,23 +14,60 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
-import { AlertCircle, Settings, Scissors } from "lucide-react"
-import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import { API_ENDPOINTS, isEndpointConfigured, postJSON } from "@/lib/api"
+import { getFirstErrorMessage } from "@/lib/forms"
+
+const cuttingSchema = z.object({
+  orderNumber: z.string().trim().min(1, "Номер замовлення обов'язковий"),
+  layer: z.string().trim().min(1, "Настіл обов'язковий"),
+  size: z
+    .string()
+    .trim()
+    .min(1, "Вкажіть розмір")
+    .refine((value) => !Number.isNaN(Number.parseFloat(value)), { message: "Розмір повинен бути числом" })
+    .refine((value) => Number.parseFloat(value) > 0, { message: "Розмір повинен бути додатним числом" }),
+  quantity: z
+    .string()
+    .trim()
+    .min(1, "Вкажіть кількість")
+    .refine((value) => /^[0-9]+$/.test(value), { message: "Кількість повинна бути цілим числом" })
+    .refine((value) => Number.parseInt(value, 10) > 0, { message: "Кількість повинна бути додатним числом" }),
+  notes: z.string().trim().max(500, "Примітки мають містити до 500 символів").optional().default(""),
+})
+
+type CuttingFormValues = z.infer<typeof cuttingSchema>
+
+const defaultValues: CuttingFormValues = {
+  orderNumber: "",
+  layer: "",
+  size: "",
+  quantity: "",
+  notes: "",
+}
 
 export function CuttingSection() {
-  const [isLoading, setIsLoading] = useState(false)
   const [layerTotal, setLayerTotal] = useState(0)
   const [currentEmployee, setCurrentEmployee] = useState<string>("")
   const { toast } = useToast()
   const isConfigured = isEndpointConfigured(API_ENDPOINTS.operations)
 
-  const [formData, setFormData] = useState({
-    orderNumber: "",
-    layer: "",
-    size: "",
-    quantity: "",
-    notes: "",
+  const form = useForm<CuttingFormValues>({
+    resolver: zodResolver(cuttingSchema),
+    defaultValues,
+    mode: "onChange",
   })
+
+  const {
+    handleSubmit,
+    register,
+    reset,
+    watch,
+    formState: { errors, isSubmitting, isValid },
+  } = form
+
+  const orderNumber = watch("orderNumber")
+  const layer = watch("layer")
+  const quantity = watch("quantity")
 
   useEffect(() => {
     const savedEmployee = localStorage.getItem("currentEmployee")
@@ -35,78 +77,33 @@ export function CuttingSection() {
   }, [])
 
   useEffect(() => {
-    if (formData.orderNumber && formData.layer) {
+    if (orderNumber && layer) {
       const existingCutting = JSON.parse(localStorage.getItem("shift_cutting") || "[]")
       const layerItems = existingCutting.filter(
-        (item: any) => item.orderNumber === formData.orderNumber && item.layer === formData.layer,
+        (item: any) => item.orderNumber === orderNumber && item.layer === layer,
       )
-      const total = layerItems.reduce((sum: number, item: any) => sum + item.quantity, 0)
+      const total = layerItems.reduce((sum: number, item: any) => sum + Number(item.quantity ?? 0), 0)
       setLayerTotal(total)
     } else {
       setLayerTotal(0)
     }
-  }, [formData.orderNumber, formData.layer])
+  }, [orderNumber, layer])
 
-  const getRequiredFieldsStatus = () => {
-    const missingFields = []
-    if (!formData.orderNumber) missingFields.push("Номер замовлення")
-    if (!formData.layer) missingFields.push("Настіл")
-    if (!formData.size) missingFields.push("Розмір")
-    if (!formData.quantity) missingFields.push("Кількість")
-
-    return {
-      isValid: missingFields.length === 0,
-      missingFields,
-    }
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    const { isValid, missingFields } = getRequiredFieldsStatus()
-
-    if (!isValid) {
-      const employeeName = currentEmployee || "швея"
-      toast({
-        title: `Шановна ${employeeName}`,
-        description: `Неможливо зробити запис. Заповніть поля: ${missingFields.join(", ")}`,
-        variant: "destructive",
-      })
-      return
-    }
-
-    const sizeNum = Number.parseFloat(formData.size)
-    if (isNaN(sizeNum) || sizeNum <= 0) {
-      const employeeName = currentEmployee || "швея"
-      toast({
-        title: `Шановна ${employeeName}`,
-        description: "Неможливо зробити запис. Розмір повинен бути додатним числом",
-        variant: "destructive",
-      })
-      return
-    }
-
-    const quantityNum = Number.parseInt(formData.quantity)
-    if (isNaN(quantityNum) || quantityNum <= 0) {
-      const employeeName = currentEmployee || "швея"
-      toast({
-        title: `Шановна ${employeeName}`,
-        description: "Неможливо зробити запис. Кількість повинна бути додатним числом",
-        variant: "destructive",
-      })
-      return
-    }
-
-    setIsLoading(true)
+  const handleValidSubmit = async (values: CuttingFormValues) => {
+    const sizeNum = Number.parseFloat(values.size)
+    const quantityNum = Number.parseInt(values.quantity, 10)
+    const notes = values.notes?.trim() ?? ""
 
     const cuttingData = {
       id: Date.now().toString(),
-      ...formData,
+      orderNumber: values.orderNumber.trim(),
+      layer: values.layer.trim(),
       size: sizeNum,
       quantity: quantityNum,
+      notes,
       timestamp: new Date().toISOString(),
       user_id: "telegram_user_id",
-      type: "cutting",
+      type: "cutting" as const,
     }
 
     try {
@@ -117,18 +114,10 @@ export function CuttingSection() {
       if (!isConfigured) {
         toast({
           title: "Розкрій записано (демо)",
-          description: `Замовлення ${formData.orderNumber}, Настіл ${formData.layer}: ${formData.size} см - ${formData.quantity} шт.`,
+          description: `Замовлення ${cuttingData.orderNumber}, Настіл ${cuttingData.layer}: ${cuttingData.size} см - ${cuttingData.quantity} шт.`,
         })
 
-        setFormData({
-          orderNumber: "",
-          layer: "",
-          size: "",
-          quantity: "",
-          notes: "",
-        })
-
-        setIsLoading(false)
+        reset(defaultValues)
         return
       }
 
@@ -137,16 +126,9 @@ export function CuttingSection() {
       if (result.success) {
         toast({
           title: "Розкрій записано",
-          description: `Замовлення ${formData.orderNumber}, Настіл ${formData.layer}: ${formData.size} см - ${formData.quantity} шт.`,
+          description: `Замовлення ${cuttingData.orderNumber}, Настіл ${cuttingData.layer}: ${cuttingData.size} см - ${cuttingData.quantity} шт.`,
         })
-
-        setFormData({
-          orderNumber: "",
-          layer: "",
-          size: "",
-          quantity: "",
-          notes: "",
-        })
+        reset(defaultValues)
       } else {
         toast({
           title: "Запит додано до черги",
@@ -159,12 +141,24 @@ export function CuttingSection() {
         description: "Спробуйте ще раз пізніше",
         variant: "destructive",
       })
-    } finally {
-      setIsLoading(false)
     }
   }
 
-  const { isValid } = getRequiredFieldsStatus()
+  const handleInvalidSubmit = (formErrors: FieldErrors<CuttingFormValues>) => {
+    const employeeName = currentEmployee || "швея"
+    const message =
+      getFirstErrorMessage(formErrors) ?? "Неможливо зробити запис. Перевірте правильність заповнення форми"
+
+    toast({
+      title: `Шановна ${employeeName}`,
+      description: message,
+      variant: "destructive",
+    })
+  }
+
+  const onSubmit = handleSubmit(handleValidSubmit, handleInvalidSubmit)
+
+  const currentQuantity = Number.parseInt(quantity || "0", 10) || 0
 
   return (
     <div className="space-y-4">
@@ -186,25 +180,21 @@ export function CuttingSection() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={onSubmit} className="space-y-4" noValidate>
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="orderNumber">Номер замовлення *</Label>
                 <Input
                   id="orderNumber"
-                  value={formData.orderNumber}
-                  onChange={(e) => setFormData({ ...formData, orderNumber: e.target.value })}
                   placeholder="Номер замовлення"
+                  {...register("orderNumber")}
                 />
+                <FormFieldError message={errors.orderNumber?.message} className="mt-1" />
               </div>
               <div>
                 <Label htmlFor="layer">Настіл *</Label>
-                <Input
-                  id="layer"
-                  value={formData.layer}
-                  onChange={(e) => setFormData({ ...formData, layer: e.target.value })}
-                  placeholder="Номер настилу"
-                />
+                <Input id="layer" placeholder="Номер настилу" {...register("layer")} />
+                <FormFieldError message={errors.layer?.message} className="mt-1" />
               </div>
             </div>
 
@@ -216,21 +206,15 @@ export function CuttingSection() {
                   type="number"
                   step="0.1"
                   min="0.1"
-                  value={formData.size}
-                  onChange={(e) => setFormData({ ...formData, size: e.target.value })}
                   placeholder="Розмір в см"
+                  {...register("size")}
                 />
+                <FormFieldError message={errors.size?.message} className="mt-1" />
               </div>
               <div>
                 <Label htmlFor="quantity">Кількість *</Label>
-                <Input
-                  id="quantity"
-                  type="number"
-                  min="1"
-                  value={formData.quantity}
-                  onChange={(e) => setFormData({ ...formData, quantity: e.target.value })}
-                  placeholder="0"
-                />
+                <Input id="quantity" type="number" min="1" placeholder="0" {...register("quantity")} />
+                <FormFieldError message={errors.quantity?.message} className="mt-1" />
               </div>
             </div>
 
@@ -238,8 +222,7 @@ export function CuttingSection() {
               <Alert>
                 <AlertCircle className="h-4 w-4" />
                 <AlertDescription>
-                  Загальна кількість по настилу {formData.layer}:{" "}
-                  {layerTotal + (formData.quantity ? Number.parseInt(formData.quantity) : 0)} шт.
+                  Загальна кількість по настилу {layer}: {layerTotal + currentQuantity} шт.
                 </AlertDescription>
               </Alert>
             )}
@@ -248,15 +231,15 @@ export function CuttingSection() {
               <Label htmlFor="notes">Примітки</Label>
               <Textarea
                 id="notes"
-                value={formData.notes}
-                onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
                 placeholder="Додаткова інформація..."
                 rows={3}
+                {...register("notes")}
               />
+              <FormFieldError message={errors.notes?.message} className="mt-1" />
             </div>
 
-            <Button type="submit" disabled={isLoading || !isValid} className="w-full">
-              {isLoading ? "Записую..." : "Записати розкрій"}
+            <Button type="submit" disabled={isSubmitting || !isValid} className="w-full">
+              {isSubmitting ? "Записую..." : "Записати розкрій"}
             </Button>
           </form>
         </CardContent>

--- a/components/form-field-error.tsx
+++ b/components/form-field-error.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+interface FormFieldErrorProps {
+  readonly message?: string
+  readonly className?: string
+}
+
+export function FormFieldError({ message, className }: FormFieldErrorProps) {
+  if (!message) {
+    return null
+  }
+
+  return <p className={cn("text-sm text-destructive", className)}>{message}</p>
+}

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -1,0 +1,31 @@
+import type { FieldError, FieldErrors, FieldValues } from "react-hook-form"
+
+function isFieldError(value: unknown): value is FieldError {
+  return typeof value === "object" && value !== null && "message" in value
+}
+
+export function getFirstErrorMessage<TFieldValues extends FieldValues>(
+  errors: FieldErrors<TFieldValues>,
+): string | null {
+  for (const value of Object.values(errors)) {
+    if (!value) {
+      continue
+    }
+
+    if (isFieldError(value)) {
+      if (value.message) {
+        return String(value.message)
+      }
+      continue
+    }
+
+    if (typeof value === "object") {
+      const nestedMessage = getFirstErrorMessage(value as FieldErrors<FieldValues>)
+      if (nestedMessage) {
+        return nestedMessage
+      }
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- replace manual state handling in the cutting form with a react-hook-form setup backed by a zod schema and consistent toast-based error handling
- refactor the operations, QC, and warehouse sections to share react-hook-form controllers, schema validation, and uniform submission/reset logic
- add shared helpers for field-level error messages and toast-friendly error extraction to keep validation feedback consistent

## Testing
- pnpm lint *(fails: Next.js prompts to configure ESLint interactively in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c930259e5483299b0ed2838a80080e