### PR TITLE
Add typed shift records and enforce strict typings

### DIFF
--- a/components/cutting-section.tsx
+++ b/components/cutting-section.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { AlertCircle, Settings, Scissors } from "lucide-react"
 import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import type { CuttingRecord } from "@/components/shift-section"
 
 export function CuttingSection() {
   const [isLoading, setIsLoading] = useState(false)
@@ -36,11 +37,11 @@ export function CuttingSection() {
 
   useEffect(() => {
     if (formData.orderNumber && formData.layer) {
-      const existingCutting = JSON.parse(localStorage.getItem("shift_cutting") || "[]")
+      const existingCutting = JSON.parse(localStorage.getItem("shift_cutting") || "[]") as CuttingRecord[]
       const layerItems = existingCutting.filter(
-        (item: any) => item.orderNumber === formData.orderNumber && item.layer === formData.layer,
+        (item) => item.orderNumber === formData.orderNumber && item.layer === formData.layer,
       )
-      const total = layerItems.reduce((sum: number, item: any) => sum + item.quantity, 0)
+      const total = layerItems.reduce((sum, item) => sum + item.quantity, 0)
       setLayerTotal(total)
     } else {
       setLayerTotal(0)
@@ -99,7 +100,7 @@ export function CuttingSection() {
 
     setIsLoading(true)
 
-    const cuttingData = {
+    const cuttingData: CuttingRecord = {
       id: Date.now().toString(),
       ...formData,
       size: sizeNum,
@@ -110,7 +111,7 @@ export function CuttingSection() {
     }
 
     try {
-      const existingCutting = JSON.parse(localStorage.getItem("shift_cutting") || "[]")
+      const existingCutting = JSON.parse(localStorage.getItem("shift_cutting") || "[]") as CuttingRecord[]
       existingCutting.push(cuttingData)
       localStorage.setItem("shift_cutting", JSON.stringify(existingCutting))
 
@@ -132,7 +133,7 @@ export function CuttingSection() {
         return
       }
 
-      const result = await postJSON(API_ENDPOINTS.operations, cuttingData)
+      const result = await postJSON<CuttingRecord>(API_ENDPOINTS.operations, cuttingData)
 
       if (result.success) {
         toast({

--- a/components/history-section.tsx
+++ b/components/history-section.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -11,57 +11,126 @@ import { Textarea } from "@/components/ui/textarea"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { useToast } from "@/hooks/use-toast"
 import { Trash2, Edit, Clock, Wrench, CheckCircle, Package, FileText, Scissors } from "lucide-react"
+import type {
+  CuttingRecord,
+  OperationRecord,
+  QCRecord,
+  WarehouseRecord,
+} from "@/components/shift-section"
 
-interface ShiftRecord {
-  id: string
-  type: "operations" | "qc" | "warehouse" | "cutting" // додав тип cutting
-  timestamp: string
-  data: any
+type RecordType = "operations" | "qc" | "warehouse" | "cutting"
+
+type HistoryRecord =
+  | { id: string; type: "operations"; timestamp: string; data: OperationRecord }
+  | { id: string; type: "qc"; timestamp: string; data: QCRecord }
+  | { id: string; type: "warehouse"; timestamp: string; data: WarehouseRecord }
+  | { id: string; type: "cutting"; timestamp: string; data: CuttingRecord }
+
+const STORAGE_KEYS: Record<RecordType, string> = {
+  operations: "shift_operations",
+  qc: "shift_qc",
+  warehouse: "shift_warehouse",
+  cutting: "shift_cutting",
+}
+
+const OPERATION_OPTIONS = ["Оверлок", "Прямоточка", "Розпошив"]
+const QC_OPERATION_OPTIONS = ["Прасування", "Пакування"]
+const SIZE_OPTIONS = ["XS", "S", "M", "L", "XL", "XXL"]
+const COLOR_OPTIONS = ["Білий", "Чорний", "Сірий", "Синій", "Червоний", "Зелений"]
+const PACKAGING_OPTIONS = ["Пакет", "Коробка", "Зв'язка"]
+const LOCATION_OPTIONS = ["Склад А1", "Склад А2", "Склад Б1", "Склад Б2", "Експедиція", "Відвантаження"]
+const DEFECT_REASONS = [
+  "Неправильний шов",
+  "Пошкодження тканини",
+  "Неправильний розмір",
+  "Забруднення",
+  "Неправильний колір",
+  "Відсутні деталі",
+  "Інше",
+]
+
+function parseStoredRecords<T>(key: string): T[] {
+  const raw = localStorage.getItem(key)
+  if (!raw) return []
+  try {
+    return JSON.parse(raw) as T[]
+  } catch (error) {
+    console.error(`Failed to parse records for ${key}`, error)
+    return []
+  }
+}
+
+function isValidRecord<T extends { id: string; timestamp: string }>(
+  record: T | null | undefined,
+): record is T {
+  return Boolean(record?.id && record?.timestamp)
 }
 
 export function HistorySection() {
-  const [records, setRecords] = useState<ShiftRecord[]>([])
-  const [editingRecord, setEditingRecord] = useState<ShiftRecord | null>(null)
-  const [editForm, setEditForm] = useState<any>({})
+  const [records, setRecords] = useState<HistoryRecord[]>([])
+  const [editingRecord, setEditingRecord] = useState<HistoryRecord | null>(null)
+  const [editForm, setEditForm] = useState<HistoryRecord["data"] | null>(null)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const { toast } = useToast()
 
-  useEffect(() => {
-    loadRecords()
-  }, [])
-
   const loadRecords = () => {
-    const operations = JSON.parse(localStorage.getItem("shift_operations") || "[]")
-    const qc = JSON.parse(localStorage.getItem("shift_qc") || "[]")
-    const warehouse = JSON.parse(localStorage.getItem("shift_warehouse") || "[]")
-    const cutting = JSON.parse(localStorage.getItem("shift_cutting") || "[]")
+    const operations = parseStoredRecords<OperationRecord>(STORAGE_KEYS.operations)
+    const qc = parseStoredRecords<QCRecord>(STORAGE_KEYS.qc)
+    const warehouse = parseStoredRecords<WarehouseRecord>(STORAGE_KEYS.warehouse)
+    const cutting = parseStoredRecords<CuttingRecord>(STORAGE_KEYS.cutting)
 
-    const allRecords: ShiftRecord[] = [
+    const allRecords: HistoryRecord[] = [
       ...operations
-        .filter((op: any) => op && op.id && op.timestamp)
-        .map((op: any) => ({ id: op.id, type: "operations" as const, timestamp: op.timestamp, data: op })),
+        .filter((record) => isValidRecord<OperationRecord>(record))
+        .map((op) => ({ id: op.id, type: "operations" as const, timestamp: op.timestamp, data: op })),
       ...qc
-        .filter((q: any) => q && q.id && q.timestamp)
-        .map((q: any) => ({ id: q.id, type: "qc" as const, timestamp: q.timestamp, data: q })),
+        .filter((record) => isValidRecord<QCRecord>(record))
+        .map((q) => ({ id: q.id, type: "qc" as const, timestamp: q.timestamp, data: q })),
       ...warehouse
-        .filter((w: any) => w && w.id && w.timestamp)
-        .map((w: any) => ({ id: w.id, type: "warehouse" as const, timestamp: w.timestamp, data: w })),
+        .filter((record) => isValidRecord<WarehouseRecord>(record))
+        .map((w) => ({ id: w.id, type: "warehouse" as const, timestamp: w.timestamp, data: w })),
       ...cutting
-        .filter((c: any) => c && c.id && c.timestamp)
-        .map((c: any) => ({ id: c.id, type: "cutting" as const, timestamp: c.timestamp, data: c })),
+        .filter((record) => isValidRecord<CuttingRecord>(record))
+        .map((c) => ({ id: c.id, type: "cutting" as const, timestamp: c.timestamp, data: c })),
     ]
 
     allRecords.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
     setRecords(allRecords)
   }
 
-  const deleteRecord = (record: ShiftRecord) => {
-    if (!record || !record.type) return
+  useEffect(() => {
+    loadRecords()
+  }, [])
 
-    const storageKey = `shift_${record.type}`
-    const currentRecords = JSON.parse(localStorage.getItem(storageKey) || "[]")
-    const updatedRecords = currentRecords.filter((r: any) => r.id !== record.id)
-    localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+  const deleteRecord = (record: HistoryRecord) => {
+    const storageKey = STORAGE_KEYS[record.type]
+
+    switch (record.type) {
+      case "operations": {
+        const currentRecords = parseStoredRecords<OperationRecord>(storageKey)
+        const updatedRecords = currentRecords.filter((item) => item.id !== record.id)
+        localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+        break
+      }
+      case "qc": {
+        const currentRecords = parseStoredRecords<QCRecord>(storageKey)
+        const updatedRecords = currentRecords.filter((item) => item.id !== record.id)
+        localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+        break
+      }
+      case "warehouse": {
+        const currentRecords = parseStoredRecords<WarehouseRecord>(storageKey)
+        const updatedRecords = currentRecords.filter((item) => item.id !== record.id)
+        localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+        break
+      }
+      case "cutting": {
+        const currentRecords = parseStoredRecords<CuttingRecord>(storageKey)
+        const updatedRecords = currentRecords.filter((item) => item.id !== record.id)
+        localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+        break
+      }
+    }
 
     loadRecords()
     toast({
@@ -70,27 +139,83 @@ export function HistorySection() {
     })
   }
 
-  const startEdit = (record: ShiftRecord) => {
-    if (!record || !record.type) return
-
+  const startEdit = (record: HistoryRecord) => {
     setEditingRecord(record)
     setEditForm({ ...record.data })
     setIsEditDialogOpen(true)
   }
 
   const saveEdit = () => {
-    if (!editingRecord || !editingRecord.type) return
+    if (!editingRecord || !editForm) return
 
-    const storageKey = `shift_${editingRecord.type}`
-    const currentRecords = JSON.parse(localStorage.getItem(storageKey) || "[]")
-    const updatedRecords = currentRecords.map((r: any) =>
-      r.id === editingRecord.id ? { ...editForm, id: editingRecord.id, timestamp: editingRecord.timestamp } : r,
-    )
-    localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+    const storageKey = STORAGE_KEYS[editingRecord.type]
+
+    switch (editingRecord.type) {
+      case "operations": {
+        const currentRecords = parseStoredRecords<OperationRecord>(storageKey)
+        const updatedRecords = currentRecords.map((item) =>
+          item.id === editingRecord.id
+            ? {
+                ...item,
+                ...(editForm as OperationRecord),
+                id: editingRecord.id,
+                timestamp: editingRecord.timestamp,
+              }
+            : item,
+        )
+        localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+        break
+      }
+      case "qc": {
+        const currentRecords = parseStoredRecords<QCRecord>(storageKey)
+        const updatedRecords = currentRecords.map((item) =>
+          item.id === editingRecord.id
+            ? {
+                ...item,
+                ...(editForm as QCRecord),
+                id: editingRecord.id,
+                timestamp: editingRecord.timestamp,
+              }
+            : item,
+        )
+        localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+        break
+      }
+      case "warehouse": {
+        const currentRecords = parseStoredRecords<WarehouseRecord>(storageKey)
+        const updatedRecords = currentRecords.map((item) =>
+          item.id === editingRecord.id
+            ? {
+                ...item,
+                ...(editForm as WarehouseRecord),
+                id: editingRecord.id,
+                timestamp: editingRecord.timestamp,
+              }
+            : item,
+        )
+        localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+        break
+      }
+      case "cutting": {
+        const currentRecords = parseStoredRecords<CuttingRecord>(storageKey)
+        const updatedRecords = currentRecords.map((item) =>
+          item.id === editingRecord.id
+            ? {
+                ...item,
+                ...(editForm as CuttingRecord),
+                id: editingRecord.id,
+                timestamp: editingRecord.timestamp,
+              }
+            : item,
+        )
+        localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
+        break
+      }
+    }
 
     setIsEditDialogOpen(false)
     setEditingRecord(null)
-    setEditForm({})
+    setEditForm(null)
     loadRecords()
     toast({
       title: "Запис оновлено",
@@ -101,12 +226,10 @@ export function HistorySection() {
   const cancelEdit = () => {
     setIsEditDialogOpen(false)
     setEditingRecord(null)
-    setEditForm({})
+    setEditForm(null)
   }
 
-  const getRecordIcon = (type: string) => {
-    if (!type) return <Clock className="h-4 w-4" />
-
+  const getRecordIcon = (type: RecordType) => {
     switch (type) {
       case "cutting":
         return <Scissors className="h-4 w-4" />
@@ -121,9 +244,7 @@ export function HistorySection() {
     }
   }
 
-  const getRecordTitle = (type: string) => {
-    if (!type) return "Запис"
-
+  const getRecordTitle = (type: RecordType) => {
     switch (type) {
       case "cutting":
         return "Розкрій"
@@ -146,175 +267,287 @@ export function HistorySection() {
   }
 
   const renderEditForm = () => {
-    if (!editingRecord || !editingRecord.type) return null
+    if (!editingRecord || !editForm) return null
 
     switch (editingRecord.type) {
-      case "cutting": // додав форму редагування для розкрою
+      case "cutting": {
+        const data = editForm as CuttingRecord
         return (
           <div className="space-y-4">
             <div>
               <Label>Номер замовлення</Label>
               <Input
-                value={editForm.orderNumber || ""}
-                onChange={(e) => setEditForm({ ...editForm, orderNumber: e.target.value })}
+                value={data.orderNumber}
+                onChange={(e) => setEditForm({ ...data, orderNumber: e.target.value })}
               />
             </div>
             <div>
               <Label>Настіл</Label>
               <Input
-                value={editForm.layer || ""}
-                onChange={(e) => setEditForm({ ...editForm, layer: e.target.value })}
+                value={data.layer}
+                onChange={(e) => setEditForm({ ...data, layer: e.target.value })}
               />
             </div>
             <div>
-              <Label>Розмір</Label>
-              <Select value={editForm.size || ""} onValueChange={(value) => setEditForm({ ...editForm, size: value })}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="XS">XS</SelectItem>
-                  <SelectItem value="S">S</SelectItem>
-                  <SelectItem value="M">M</SelectItem>
-                  <SelectItem value="L">L</SelectItem>
-                  <SelectItem value="XL">XL</SelectItem>
-                  <SelectItem value="XXL">XXL</SelectItem>
-                </SelectContent>
-              </Select>
+              <Label>Розмір (см)</Label>
+              <Input
+                type="number"
+                value={data.size}
+                onChange={(e) => {
+                  const value = Number.parseFloat(e.target.value)
+                  setEditForm({ ...data, size: Number.isNaN(value) ? data.size : value })
+                }}
+              />
             </div>
             <div>
               <Label>Кількість</Label>
               <Input
                 type="number"
-                value={editForm.quantity || ""}
-                onChange={(e) => setEditForm({ ...editForm, quantity: Number.parseInt(e.target.value) })}
+                value={data.quantity}
+                onChange={(e) => {
+                  const value = Number.parseInt(e.target.value, 10)
+                  setEditForm({ ...data, quantity: Number.isNaN(value) ? data.quantity : value })
+                }}
               />
             </div>
             <div>
               <Label>Примітки</Label>
               <Textarea
-                value={editForm.notes || ""}
-                onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
+                value={data.notes || ""}
+                onChange={(e) => setEditForm({ ...data, notes: e.target.value })}
               />
             </div>
           </div>
         )
-
-      case "operations":
+      }
+      case "operations": {
+        const data = editForm as OperationRecord
         return (
           <div className="space-y-4">
-            <div>
-              <Label>Номер замовлення</Label>
-              <Input
-                value={editForm.orderNumber || ""}
-                onChange={(e) => setEditForm({ ...editForm, orderNumber: e.target.value })}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Номер замовлення</Label>
+                <Input
+                  value={data.orderNumber}
+                  onChange={(e) => setEditForm({ ...data, orderNumber: e.target.value })}
+                />
+              </div>
+              <div>
+                <Label>Настіл</Label>
+                <Input
+                  value={data.layer}
+                  onChange={(e) => setEditForm({ ...data, layer: e.target.value })}
+                />
+              </div>
             </div>
-            <div>
-              <Label>Настіл</Label>
-              <Input
-                value={editForm.layer || ""}
-                onChange={(e) => setEditForm({ ...editForm, layer: e.target.value })}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Розмір</Label>
+                <Select
+                  value={data.size || ""}
+                  onValueChange={(value) => setEditForm({ ...data, size: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть розмір" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SIZE_OPTIONS.map((size) => (
+                      <SelectItem key={size} value={size}>
+                        {size}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Колір</Label>
+                <Select
+                  value={data.color || ""}
+                  onValueChange={(value) => setEditForm({ ...data, color: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть колір" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COLOR_OPTIONS.map((color) => (
+                      <SelectItem key={color} value={color}>
+                        {color}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
-            <div>
-              <Label>Операція</Label>
-              <Select
-                value={editForm.operation || ""}
-                onValueChange={(value) => setEditForm({ ...editForm, operation: value })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="Оверлок">Оверлок</SelectItem>
-                  <SelectItem value="Прямоточка">Прямоточка</SelectItem>
-                  <SelectItem value="Розпошив">Розпошив</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label>Кількість</Label>
-              <Input
-                type="number"
-                value={editForm.quantity || ""}
-                onChange={(e) => setEditForm({ ...editForm, quantity: Number.parseInt(e.target.value) })}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Операція</Label>
+                <Select
+                  value={data.operation}
+                  onValueChange={(value) => setEditForm({ ...data, operation: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть операцію" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {OPERATION_OPTIONS.map((operation) => (
+                      <SelectItem key={operation} value={operation}>
+                        {operation}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Кількість</Label>
+                <Input
+                  type="number"
+                  value={data.quantity}
+                  onChange={(e) => {
+                    const value = Number.parseInt(e.target.value, 10)
+                    setEditForm({ ...data, quantity: Number.isNaN(value) ? data.quantity : value })
+                  }}
+                />
+              </div>
             </div>
             <div>
               <Label>Примітки</Label>
               <Textarea
-                value={editForm.notes || ""}
-                onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
+                value={data.notes || ""}
+                onChange={(e) => setEditForm({ ...data, notes: e.target.value })}
               />
             </div>
           </div>
         )
-
-      case "qc":
+      }
+      case "qc": {
+        const data = editForm as QCRecord
         return (
           <div className="space-y-4">
-            <div>
-              <Label>Номер замовлення</Label>
-              <Input
-                value={editForm.orderNumber || ""}
-                onChange={(e) => setEditForm({ ...editForm, orderNumber: e.target.value })}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Операція</Label>
+                <Select
+                  value={data.operation}
+                  onValueChange={(value) => setEditForm({ ...data, operation: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть операцію" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {QC_OPERATION_OPTIONS.map((operation) => (
+                      <SelectItem key={operation} value={operation}>
+                        {operation}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Товар</Label>
+                <Input
+                  value={data.product}
+                  onChange={(e) => setEditForm({ ...data, product: e.target.value })}
+                />
+              </div>
             </div>
-            <div>
-              <Label>Настіл</Label>
-              <Input
-                value={editForm.layer || ""}
-                onChange={(e) => setEditForm({ ...editForm, layer: e.target.value })}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>SKU</Label>
+                <Input
+                  value={data.sku || ""}
+                  onChange={(e) => setEditForm({ ...data, sku: e.target.value })}
+                />
+              </div>
+              <div>
+                <Label>Розмір</Label>
+                <Select
+                  value={data.size || ""}
+                  onValueChange={(value) => setEditForm({ ...data, size: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть розмір" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SIZE_OPTIONS.map((size) => (
+                      <SelectItem key={size} value={size}>
+                        {size}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
-            <div>
-              <Label>Операція</Label>
-              <Select
-                value={editForm.operation || ""}
-                onValueChange={(value) => setEditForm({ ...editForm, operation: value })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="Прасування">Прасування</SelectItem>
-                  <SelectItem value="Пакування">Пакування</SelectItem>
-                </SelectContent>
-              </Select>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Колір</Label>
+                <Select
+                  value={data.color || ""}
+                  onValueChange={(value) => setEditForm({ ...data, color: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть колір" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COLOR_OPTIONS.map((color) => (
+                      <SelectItem key={color} value={color}>
+                        {color}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Загальна кількість</Label>
+                <Input
+                  type="number"
+                  value={data.totalQty}
+                  onChange={(e) => {
+                    const value = Number.parseInt(e.target.value, 10)
+                    setEditForm({ ...data, totalQty: Number.isNaN(value) ? data.totalQty : value })
+                  }}
+                />
+              </div>
             </div>
-            <div>
-              <Label>Прийнято</Label>
-              <Input
-                type="number"
-                value={editForm.accepted_qty || ""}
-                onChange={(e) => setEditForm({ ...editForm, accepted_qty: Number.parseInt(e.target.value) })}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Прийнято</Label>
+                <Input
+                  type="number"
+                  value={data.acceptedQty}
+                  onChange={(e) => {
+                    const value = Number.parseInt(e.target.value, 10)
+                    setEditForm({ ...data, acceptedQty: Number.isNaN(value) ? data.acceptedQty : value })
+                  }}
+                />
+              </div>
+              <div>
+                <Label>Відхилено</Label>
+                <Input
+                  type="number"
+                  value={data.rejectedQty}
+                  onChange={(e) => {
+                    const value = Number.parseInt(e.target.value, 10)
+                    setEditForm({ ...data, rejectedQty: Number.isNaN(value) ? data.rejectedQty : value })
+                  }}
+                />
+              </div>
             </div>
-            <div>
-              <Label>Відхилено</Label>
-              <Input
-                type="number"
-                value={editForm.rejected_qty || ""}
-                onChange={(e) => setEditForm({ ...editForm, rejected_qty: Number.parseInt(e.target.value) })}
-              />
-            </div>
-            {editForm.rejected_qty > 0 && (
+            {data.rejectedQty > 0 && (
               <div>
                 <Label>Причина браку</Label>
                 <Select
-                  value={editForm.defect_reason || ""}
-                  onValueChange={(value) => setEditForm({ ...editForm, defect_reason: value })}
+                  value={data.defectReason || ""}
+                  onValueChange={(value) => setEditForm({ ...data, defectReason: value })}
                 >
                   <SelectTrigger>
-                    <SelectValue />
+                    <SelectValue placeholder="Оберіть причину" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="wrong_size">Невірний розмір</SelectItem>
-                    <SelectItem value="fabric_defect">Брак тканини</SelectItem>
-                    <SelectItem value="sewing_defect">Брак пошиття</SelectItem>
-                    <SelectItem value="color_mismatch">Невідповідність кольору</SelectItem>
-                    <SelectItem value="damaged">Пошкоджено</SelectItem>
+                    {DEFECT_REASONS.map((reason) => (
+                      <SelectItem key={reason} value={reason}>
+                        {reason}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -322,82 +555,297 @@ export function HistorySection() {
             <div>
               <Label>Примітки</Label>
               <Textarea
-                value={editForm.notes || ""}
-                onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
+                value={data.notes || ""}
+                onChange={(e) => setEditForm({ ...data, notes: e.target.value })}
               />
             </div>
           </div>
         )
-
-      case "warehouse":
+      }
+      case "warehouse": {
+        const data = editForm as WarehouseRecord
         return (
           <div className="space-y-4">
-            <div>
-              <Label>Номер замовлення</Label>
-              <Input
-                value={editForm.orderNumber || ""}
-                onChange={(e) => setEditForm({ ...editForm, orderNumber: e.target.value })}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Товар</Label>
+                <Input
+                  value={data.product}
+                  onChange={(e) => setEditForm({ ...data, product: e.target.value })}
+                />
+              </div>
+              <div>
+                <Label>SKU</Label>
+                <Input
+                  value={data.sku || ""}
+                  onChange={(e) => setEditForm({ ...data, sku: e.target.value })}
+                />
+              </div>
             </div>
-            <div>
-              <Label>Настіл</Label>
-              <Input
-                value={editForm.layer || ""}
-                onChange={(e) => setEditForm({ ...editForm, layer: e.target.value })}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Розмір</Label>
+                <Select
+                  value={data.size || ""}
+                  onValueChange={(value) => setEditForm({ ...data, size: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть розмір" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SIZE_OPTIONS.map((size) => (
+                      <SelectItem key={size} value={size}>
+                        {size}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Колір</Label>
+                <Select
+                  value={data.color || ""}
+                  onValueChange={(value) => setEditForm({ ...data, color: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть колір" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COLOR_OPTIONS.map((color) => (
+                      <SelectItem key={color} value={color}>
+                        {color}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
-            <div>
-              <Label>Кількість</Label>
-              <Input
-                type="number"
-                value={editForm.quantity || ""}
-                onChange={(e) => setEditForm({ ...editForm, quantity: Number.parseInt(e.target.value) })}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Кількість</Label>
+                <Input
+                  type="number"
+                  value={data.quantity}
+                  onChange={(e) => {
+                    const value = Number.parseInt(e.target.value, 10)
+                    setEditForm({ ...data, quantity: Number.isNaN(value) ? data.quantity : value })
+                  }}
+                />
+              </div>
+              <div>
+                <Label>Упаковка</Label>
+                <Select
+                  value={data.packaging || ""}
+                  onValueChange={(value) => setEditForm({ ...data, packaging: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть упаковку" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PACKAGING_OPTIONS.map((packaging) => (
+                      <SelectItem key={packaging} value={packaging}>
+                        {packaging}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
-            <div>
-              <Label>Упаковка</Label>
-              <Select
-                value={editForm.packaging || ""}
-                onValueChange={(value) => setEditForm({ ...editForm, packaging: value })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="пакет">Пакет</SelectItem>
-                  <SelectItem value="коробка">Коробка</SelectItem>
-                  <SelectItem value="зв'язка">Зв'язка</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label>Місце на складі</Label>
-              <Select
-                value={editForm.warehouse_location || ""}
-                onValueChange={(value) => setEditForm({ ...editForm, warehouse_location: value })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="A1">Зона A1</SelectItem>
-                  <SelectItem value="A2">Зона A2</SelectItem>
-                  <SelectItem value="B1">Зона B1</SelectItem>
-                  <SelectItem value="B2">Зона B2</SelectItem>
-                  <SelectItem value="C1">Зона C1</SelectItem>
-                </SelectContent>
-              </Select>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Місце на складі</Label>
+                <Select
+                  value={data.location}
+                  onValueChange={(value) => setEditForm({ ...data, location: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Оберіть місце" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {LOCATION_OPTIONS.map((location) => (
+                      <SelectItem key={location} value={location}>
+                        {location}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Отримувач</Label>
+                <Input
+                  value={data.receiver || ""}
+                  onChange={(e) => setEditForm({ ...data, receiver: e.target.value })}
+                />
+              </div>
             </div>
             <div>
               <Label>Примітки</Label>
               <Textarea
-                value={editForm.notes || ""}
-                onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
+                value={data.notes || ""}
+                onChange={(e) => setEditForm({ ...data, notes: e.target.value })}
               />
             </div>
           </div>
         )
+      }
+      default:
+        return null
+    }
+  }
 
+  const renderRecordDetails = (record: HistoryRecord) => {
+    switch (record.type) {
+      case "cutting": {
+        const data = record.data
+        return (
+          <>
+            <div>
+              <strong>Замовлення:</strong> {data.orderNumber}
+            </div>
+            <div>
+              <strong>Настіл:</strong> {data.layer}
+            </div>
+            <div>
+              <strong>Розмір:</strong> {data.size} см
+            </div>
+            <div>
+              <strong>Кількість:</strong> {data.quantity}
+            </div>
+            {data.notes && (
+              <div>
+                <strong>Примітки:</strong> {data.notes}
+              </div>
+            )}
+          </>
+        )
+      }
+      case "operations": {
+        const data = record.data
+        return (
+          <>
+            <div>
+              <strong>Замовлення:</strong> {data.orderNumber}
+            </div>
+            <div>
+              <strong>Настіл:</strong> {data.layer}
+            </div>
+            {data.size && (
+              <div>
+                <strong>Розмір:</strong> {data.size}
+              </div>
+            )}
+            {data.color && (
+              <div>
+                <strong>Колір:</strong> {data.color}
+              </div>
+            )}
+            <div>
+              <strong>Операція:</strong> {data.operation}
+            </div>
+            <div>
+              <strong>Кількість:</strong> {data.quantity}
+            </div>
+            {data.notes && (
+              <div>
+                <strong>Примітки:</strong> {data.notes}
+              </div>
+            )}
+          </>
+        )
+      }
+      case "qc": {
+        const data = record.data
+        return (
+          <>
+            <div>
+              <strong>Операція:</strong> {data.operation}
+            </div>
+            <div>
+              <strong>Товар:</strong> {data.product}
+            </div>
+            {data.sku && (
+              <div>
+                <strong>SKU:</strong> {data.sku}
+              </div>
+            )}
+            {data.size && (
+              <div>
+                <strong>Розмір:</strong> {data.size}
+              </div>
+            )}
+            {data.color && (
+              <div>
+                <strong>Колір:</strong> {data.color}
+              </div>
+            )}
+            <div>
+              <strong>Загалом:</strong> {data.totalQty}
+            </div>
+            <div>
+              <strong>Прийнято:</strong> {data.acceptedQty}
+            </div>
+            <div>
+              <strong>Брак:</strong> {data.rejectedQty}
+            </div>
+            {data.defectReason && (
+              <div>
+                <strong>Причина браку:</strong> {data.defectReason}
+              </div>
+            )}
+            {data.notes && (
+              <div>
+                <strong>Примітки:</strong> {data.notes}
+              </div>
+            )}
+          </>
+        )
+      }
+      case "warehouse": {
+        const data = record.data
+        return (
+          <>
+            <div>
+              <strong>Товар:</strong> {data.product}
+            </div>
+            {data.sku && (
+              <div>
+                <strong>SKU:</strong> {data.sku}
+              </div>
+            )}
+            {data.size && (
+              <div>
+                <strong>Розмір:</strong> {data.size}
+              </div>
+            )}
+            {data.color && (
+              <div>
+                <strong>Колір:</strong> {data.color}
+              </div>
+            )}
+            <div>
+              <strong>Кількість:</strong> {data.quantity}
+            </div>
+            {data.packaging && (
+              <div>
+                <strong>Упаковка:</strong> {data.packaging}
+              </div>
+            )}
+            <div>
+              <strong>Місце:</strong> {data.location}
+            </div>
+            {data.receiver && (
+              <div>
+                <strong>Отримувач:</strong> {data.receiver}
+              </div>
+            )}
+            {data.notes && (
+              <div>
+                <strong>Примітки:</strong> {data.notes}
+              </div>
+            )}
+          </>
+        )
+      }
       default:
         return null
     }
@@ -437,7 +885,16 @@ export function HistorySection() {
                   </Badge>
                 </div>
                 <div className="flex gap-1">
-                  <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+                  <Dialog
+                    open={isEditDialogOpen}
+                    onOpenChange={(open) => {
+                      setIsEditDialogOpen(open)
+                      if (!open) {
+                        setEditingRecord(null)
+                        setEditForm(null)
+                      }
+                    }}
+                  >
                     <DialogTrigger asChild>
                       <Button variant="ghost" size="sm" onClick={() => startEdit(record)}>
                         <Edit className="h-3 w-3" />
@@ -464,70 +921,7 @@ export function HistorySection() {
               </div>
             </CardHeader>
             <CardContent className="pt-0">
-              <div className="text-sm space-y-1">
-                <div>
-                  <strong>Замовлення:</strong> {record.data.orderNumber}
-                </div>
-                <div>
-                  <strong>Настіл:</strong> {record.data.layer}
-                </div>
-                {record.type === "cutting" && ( // додав відображення даних розкрою
-                  <>
-                    <div>
-                      <strong>Розмір:</strong> {record.data.size}
-                    </div>
-                    <div>
-                      <strong>Кількість:</strong> {record.data.quantity}
-                    </div>
-                  </>
-                )}
-                {record.type === "operations" && (
-                  <>
-                    <div>
-                      <strong>Операція:</strong> {record.data.operation}
-                    </div>
-                    <div>
-                      <strong>Кількість:</strong> {record.data.quantity}
-                    </div>
-                  </>
-                )}
-                {record.type === "qc" && (
-                  <>
-                    <div>
-                      <strong>Операція:</strong> {record.data.operation}
-                    </div>
-                    <div>
-                      <strong>Прийнято:</strong> {record.data.accepted_qty}
-                    </div>
-                    <div>
-                      <strong>Відхилено:</strong> {record.data.rejected_qty}
-                    </div>
-                    {record.data.defect_reason && (
-                      <div>
-                        <strong>Причина браку:</strong> {record.data.defect_reason}
-                      </div>
-                    )}
-                  </>
-                )}
-                {record.type === "warehouse" && (
-                  <>
-                    <div>
-                      <strong>Кількість:</strong> {record.data.quantity}
-                    </div>
-                    <div>
-                      <strong>Упаковка:</strong> {record.data.packaging}
-                    </div>
-                    <div>
-                      <strong>Місце:</strong> {record.data.warehouse_location}
-                    </div>
-                  </>
-                )}
-                {record.data.notes && (
-                  <div>
-                    <strong>Примітки:</strong> {record.data.notes}
-                  </div>
-                )}
-              </div>
+              <div className="text-sm space-y-1">{renderRecordDetails(record)}</div>
             </CardContent>
           </Card>
         ))}

--- a/components/operations-section.tsx
+++ b/components/operations-section.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { AlertCircle, Settings } from "lucide-react"
 import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import type { OperationRecord } from "@/components/shift-section"
 
 export function OperationsSection() {
   const [isLoading, setIsLoading] = useState(false)
@@ -72,7 +73,7 @@ export function OperationsSection() {
 
     setIsLoading(true)
 
-    const operationData = {
+    const operationData: OperationRecord = {
       id: Date.now().toString(),
       ...formData,
       quantity: Number.parseInt(formData.quantity),
@@ -81,7 +82,9 @@ export function OperationsSection() {
     }
 
     try {
-      const existingOperations = JSON.parse(localStorage.getItem("shift_operations") || "[]")
+      const existingOperations = JSON.parse(
+        localStorage.getItem("shift_operations") || "[]",
+      ) as OperationRecord[]
       existingOperations.push(operationData)
       localStorage.setItem("shift_operations", JSON.stringify(existingOperations))
 
@@ -105,7 +108,7 @@ export function OperationsSection() {
         return
       }
 
-      const result = await postJSON(API_ENDPOINTS.operations, operationData)
+      const result = await postJSON<OperationRecord>(API_ENDPOINTS.operations, operationData)
 
       if (result.success) {
         toast({

--- a/components/qc-section.tsx
+++ b/components/qc-section.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { AlertCircle, Settings, CheckCircle, XCircle, Package } from "lucide-react"
 import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import type { QCRecord } from "@/components/shift-section"
 
 export function QCSection() {
   const [isLoading, setIsLoading] = useState(false)
@@ -98,7 +99,7 @@ export function QCSection() {
 
     setIsLoading(true)
 
-    const qcData = {
+    const qcData: QCRecord = {
       id: Date.now().toString(),
       ...formData,
       totalQty,
@@ -109,11 +110,12 @@ export function QCSection() {
     }
 
     try {
-      const existingQC = JSON.parse(localStorage.getItem("shift_qc") || "[]")
-      existingQC.push({
+      const existingQC = JSON.parse(localStorage.getItem("shift_qc") || "[]") as QCRecord[]
+      const qcRecord: QCRecord = {
         ...qcData,
-        employee: currentEmployee,
-      })
+        employee: currentEmployee || undefined,
+      }
+      existingQC.push(qcRecord)
       localStorage.setItem("shift_qc", JSON.stringify(existingQC))
 
       if (!isConfigured) {
@@ -138,7 +140,7 @@ export function QCSection() {
         return
       }
 
-      const result = await postJSON(API_ENDPOINTS.qc, qcData)
+      const result = await postJSON<QCRecord>(API_ENDPOINTS.qc, qcData)
 
       if (result.success) {
         toast({

--- a/components/warehouse-section.tsx
+++ b/components/warehouse-section.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { AlertCircle, Settings, Package } from "lucide-react"
 import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import type { WarehouseRecord } from "@/components/shift-section"
 
 export function WarehouseSection() {
   const [isLoading, setIsLoading] = useState(false)
@@ -74,7 +75,7 @@ export function WarehouseSection() {
 
     setIsLoading(true)
 
-    const warehouseData = {
+    const warehouseData: WarehouseRecord = {
       id: Date.now().toString(),
       ...formData,
       quantity: Number.parseInt(formData.quantity),
@@ -83,7 +84,9 @@ export function WarehouseSection() {
     }
 
     try {
-      const existingWarehouse = JSON.parse(localStorage.getItem("shift_warehouse") || "[]")
+      const existingWarehouse = JSON.parse(
+        localStorage.getItem("shift_warehouse") || "[]",
+      ) as WarehouseRecord[]
       existingWarehouse.push(warehouseData)
       localStorage.setItem("shift_warehouse", JSON.stringify(existingWarehouse))
 
@@ -109,7 +112,7 @@ export function WarehouseSection() {
         return
       }
 
-      const result = await postJSON(API_ENDPOINTS.warehouse, warehouseData)
+      const result = await postJSON<WarehouseRecord>(API_ENDPOINTS.warehouse, warehouseData)
 
       if (result.success) {
         toast({

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,10 +1,13 @@
-interface ApiResponse {
+export interface ApiResponse<T = unknown> {
   success: boolean
-  data?: any
+  data?: T
   error?: string
 }
 
-export async function postJSON(url: string, data: any): Promise<ApiResponse> {
+export async function postJSON<TRequest extends object, TResponse = unknown>(
+  url: string,
+  data: TRequest,
+): Promise<ApiResponse<TResponse>> {
   try {
     // Check if we have the required environment variables
     if (!url || url.includes("undefined")) {
@@ -26,7 +29,7 @@ export async function postJSON(url: string, data: any): Promise<ApiResponse> {
       throw new Error(`HTTP error! status: ${response.status}`)
     }
 
-    const result = await response.json()
+    const result = (await response.json()) as TResponse
     return { success: true, data: result }
   } catch (error) {
     console.error("API request failed:", error)
@@ -38,7 +41,7 @@ export async function postJSON(url: string, data: any): Promise<ApiResponse> {
 }
 
 export function isEndpointConfigured(endpoint: string): boolean {
-  return endpoint && endpoint.length > 0 && !endpoint.includes("undefined")
+  return Boolean(endpoint) && endpoint.length > 0 && !endpoint.includes("undefined")
 }
 
 export function isDevelopmentMode(): boolean {

--- a/lib/offline-queue.ts
+++ b/lib/offline-queue.ts
@@ -1,7 +1,7 @@
-interface QueuedRequest {
+interface QueuedRequest<TData = unknown> {
   id: string
   url: string
-  data: any
+  data: TData
   timestamp: number
   retryCount: number
 }
@@ -30,10 +30,10 @@ class OfflineQueue {
     })
   }
 
-  async addRequest(url: string, data: any): Promise<void> {
+  async addRequest<TData>(url: string, data: TData): Promise<void> {
     if (!this.db) await this.init()
 
-    const request: QueuedRequest = {
+    const request: QueuedRequest<TData> = {
       id: Date.now().toString(),
       url,
       data,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "ES6",
     "skipLibCheck": true,
     "strict": true,
+    "noImplicitAny": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- add reusable interfaces for shift-related records and wire them into the shift workflow
- refactor history management to use the typed records with improved edit forms and detail rendering
- tighten API helpers, offline queue handling, and TypeScript configuration for stronger type safety

## Testing
- pnpm exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68c9301f66648329b5e6b017a20205b0