### PR TITLE
Add SectionId type for bottom navigation state

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,10 +7,10 @@ import { OperationsSection } from "@/components/operations-section"
 import { QCSection } from "@/components/qc-section"
 import { WarehouseSection } from "@/components/warehouse-section"
 import { HistorySection } from "@/components/history-section"
-import { BottomNavigation } from "@/components/bottom-navigation"
+import { BottomNavigation, type SectionId } from "@/components/bottom-navigation"
 
 export default function HomePage() {
-  const [activeSection, setActiveSection] = useState("shift")
+  const [activeSection, setActiveSection] = useState<SectionId>("shift")
   const [isShiftActive, setIsShiftActive] = useState(false)
 
   useEffect(() => {
@@ -51,8 +51,10 @@ export default function HomePage() {
         return <WarehouseSection />
       case "history":
         return <HistorySection />
-      default:
-        return <ShiftSection />
+      default: {
+        const _exhaustiveCheck: never = activeSection
+        throw new Error(`Unhandled section: ${_exhaustiveCheck}`)
+      }
     }
   }
 

--- a/components/bottom-navigation.tsx
+++ b/components/bottom-navigation.tsx
@@ -1,16 +1,24 @@
 "use client"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import type { LucideIcon } from "lucide-react"
 import { Clock, Wrench, CheckCircle, Package, History, Scissors } from "lucide-react"
 
+export type SectionId = "shift" | "cutting" | "operations" | "qc" | "warehouse" | "history"
+
 interface BottomNavigationProps {
-  activeSection: string
-  onSectionChange: (section: string) => void
+  activeSection: SectionId
+  onSectionChange: (section: SectionId) => void
   isShiftActive: boolean
 }
 
 export function BottomNavigation({ activeSection, onSectionChange, isShiftActive }: BottomNavigationProps) {
-  const sections = [
+  const sections: Array<{
+    id: SectionId
+    label: string
+    icon: LucideIcon
+    enabled: boolean
+  }> = [
     {
       id: "shift",
       label: "Зміна",


### PR DESCRIPTION
## Summary
- define a shared SectionId union type for the bottom navigation
- update the bottom navigation props and section metadata to use the new union
- switch the home page to manage activeSection state with SectionId and ensure exhaustive rendering

## Testing
- pnpm lint *(fails: prompts to configure ESLint in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c9301b04f0832999bf7265bcc237db