### PR TITLE
Unify shift storage keys across sections

### DIFF
--- a/components/cutting-section.tsx
+++ b/components/cutting-section.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { AlertCircle, Settings, Scissors } from "lucide-react"
 import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import { SHIFT_STORAGE_KEYS } from "@/lib/utils"
 
 export function CuttingSection() {
   const [isLoading, setIsLoading] = useState(false)
@@ -36,7 +37,7 @@ export function CuttingSection() {
 
   useEffect(() => {
     if (formData.orderNumber && formData.layer) {
-      const existingCutting = JSON.parse(localStorage.getItem("shift_cutting") || "[]")
+      const existingCutting = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.cutting) || "[]")
       const layerItems = existingCutting.filter(
         (item: any) => item.orderNumber === formData.orderNumber && item.layer === formData.layer,
       )
@@ -110,9 +111,9 @@ export function CuttingSection() {
     }
 
     try {
-      const existingCutting = JSON.parse(localStorage.getItem("shift_cutting") || "[]")
+      const existingCutting = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.cutting) || "[]")
       existingCutting.push(cuttingData)
-      localStorage.setItem("shift_cutting", JSON.stringify(existingCutting))
+      localStorage.setItem(SHIFT_STORAGE_KEYS.cutting, JSON.stringify(existingCutting))
 
       if (!isConfigured) {
         toast({

--- a/components/history-section.tsx
+++ b/components/history-section.tsx
@@ -11,10 +11,13 @@ import { Textarea } from "@/components/ui/textarea"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { useToast } from "@/hooks/use-toast"
 import { Trash2, Edit, Clock, Wrench, CheckCircle, Package, FileText, Scissors } from "lucide-react"
+import { SHIFT_STORAGE_KEYS } from "@/lib/utils"
+
+type ShiftRecordType = keyof typeof SHIFT_STORAGE_KEYS
 
 interface ShiftRecord {
   id: string
-  type: "operations" | "qc" | "warehouse" | "cutting" // додав тип cutting
+  type: ShiftRecordType
   timestamp: string
   data: any
 }
@@ -31,10 +34,10 @@ export function HistorySection() {
   }, [])
 
   const loadRecords = () => {
-    const operations = JSON.parse(localStorage.getItem("shift_operations") || "[]")
-    const qc = JSON.parse(localStorage.getItem("shift_qc") || "[]")
-    const warehouse = JSON.parse(localStorage.getItem("shift_warehouse") || "[]")
-    const cutting = JSON.parse(localStorage.getItem("shift_cutting") || "[]")
+    const operations = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.operations) || "[]")
+    const qc = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.qc) || "[]")
+    const warehouse = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.warehouse) || "[]")
+    const cutting = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.cutting) || "[]")
 
     const allRecords: ShiftRecord[] = [
       ...operations
@@ -58,7 +61,7 @@ export function HistorySection() {
   const deleteRecord = (record: ShiftRecord) => {
     if (!record || !record.type) return
 
-    const storageKey = `shift_${record.type}`
+    const storageKey = SHIFT_STORAGE_KEYS[record.type]
     const currentRecords = JSON.parse(localStorage.getItem(storageKey) || "[]")
     const updatedRecords = currentRecords.filter((r: any) => r.id !== record.id)
     localStorage.setItem(storageKey, JSON.stringify(updatedRecords))
@@ -81,7 +84,7 @@ export function HistorySection() {
   const saveEdit = () => {
     if (!editingRecord || !editingRecord.type) return
 
-    const storageKey = `shift_${editingRecord.type}`
+    const storageKey = SHIFT_STORAGE_KEYS[editingRecord.type]
     const currentRecords = JSON.parse(localStorage.getItem(storageKey) || "[]")
     const updatedRecords = currentRecords.map((r: any) =>
       r.id === editingRecord.id ? { ...editForm, id: editingRecord.id, timestamp: editingRecord.timestamp } : r,

--- a/components/operations-section.tsx
+++ b/components/operations-section.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { AlertCircle, Settings } from "lucide-react"
 import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import { SHIFT_STORAGE_KEYS } from "@/lib/utils"
 
 export function OperationsSection() {
   const [isLoading, setIsLoading] = useState(false)
@@ -81,9 +82,9 @@ export function OperationsSection() {
     }
 
     try {
-      const existingOperations = JSON.parse(localStorage.getItem("shift_operations") || "[]")
+      const existingOperations = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.operations) || "[]")
       existingOperations.push(operationData)
-      localStorage.setItem("shift_operations", JSON.stringify(existingOperations))
+      localStorage.setItem(SHIFT_STORAGE_KEYS.operations, JSON.stringify(existingOperations))
 
       if (!isConfigured) {
         toast({

--- a/components/qc-section.tsx
+++ b/components/qc-section.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { AlertCircle, Settings, CheckCircle, XCircle, Package } from "lucide-react"
 import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import { SHIFT_STORAGE_KEYS } from "@/lib/utils"
 
 export function QCSection() {
   const [isLoading, setIsLoading] = useState(false)
@@ -109,12 +110,12 @@ export function QCSection() {
     }
 
     try {
-      const existingQC = JSON.parse(localStorage.getItem("shift_qc") || "[]")
+      const existingQC = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.qc) || "[]")
       existingQC.push({
         ...qcData,
         employee: currentEmployee,
       })
-      localStorage.setItem("shift_qc", JSON.stringify(existingQC))
+      localStorage.setItem(SHIFT_STORAGE_KEYS.qc, JSON.stringify(existingQC))
 
       if (!isConfigured) {
         toast({

--- a/components/shift-section.tsx
+++ b/components/shift-section.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useToast } from "@/hooks/use-toast"
 import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import { SHIFT_STORAGE_KEYS } from "@/lib/utils"
 import { offlineQueue } from "@/lib/offline-queue"
 import { AlertCircle, Settings, User } from "lucide-react"
 
@@ -77,14 +78,14 @@ export function ShiftSection() {
 
     if (action === "start") {
       shiftData.employee = selectedEmployee
-      localStorage.removeItem("shiftOperations")
-      localStorage.removeItem("shiftQC")
-      localStorage.removeItem("shiftWarehouse")
+      localStorage.removeItem(SHIFT_STORAGE_KEYS.operations)
+      localStorage.removeItem(SHIFT_STORAGE_KEYS.qc)
+      localStorage.removeItem(SHIFT_STORAGE_KEYS.warehouse)
     } else {
       shiftData.employee = currentEmployee
-      const operations = JSON.parse(localStorage.getItem("shiftOperations") || "[]")
-      const qc = JSON.parse(localStorage.getItem("shiftQC") || "[]")
-      const warehouse = JSON.parse(localStorage.getItem("shiftWarehouse") || "[]")
+      const operations = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.operations) || "[]")
+      const qc = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.qc) || "[]")
+      const warehouse = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.warehouse) || "[]")
 
       shiftData.shift_data = {
         operations,
@@ -107,9 +108,9 @@ export function ShiftSection() {
         } else {
           setCurrentEmployee("")
           localStorage.removeItem("currentEmployee")
-          localStorage.removeItem("shiftOperations")
-          localStorage.removeItem("shiftQC")
-          localStorage.removeItem("shiftWarehouse")
+          localStorage.removeItem(SHIFT_STORAGE_KEYS.operations)
+          localStorage.removeItem(SHIFT_STORAGE_KEYS.qc)
+          localStorage.removeItem(SHIFT_STORAGE_KEYS.warehouse)
         }
 
         const shiftRecord: ShiftRecord = {
@@ -156,9 +157,9 @@ export function ShiftSection() {
         } else {
           setCurrentEmployee("")
           localStorage.removeItem("currentEmployee")
-          localStorage.removeItem("shiftOperations")
-          localStorage.removeItem("shiftQC")
-          localStorage.removeItem("shiftWarehouse")
+          localStorage.removeItem(SHIFT_STORAGE_KEYS.operations)
+          localStorage.removeItem(SHIFT_STORAGE_KEYS.qc)
+          localStorage.removeItem(SHIFT_STORAGE_KEYS.warehouse)
         }
 
         // Add to recent shifts

--- a/components/warehouse-section.tsx
+++ b/components/warehouse-section.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import { AlertCircle, Settings, Package } from "lucide-react"
 import { postJSON, API_ENDPOINTS, isEndpointConfigured } from "@/lib/api"
+import { SHIFT_STORAGE_KEYS } from "@/lib/utils"
 
 export function WarehouseSection() {
   const [isLoading, setIsLoading] = useState(false)
@@ -83,9 +84,9 @@ export function WarehouseSection() {
     }
 
     try {
-      const existingWarehouse = JSON.parse(localStorage.getItem("shift_warehouse") || "[]")
+      const existingWarehouse = JSON.parse(localStorage.getItem(SHIFT_STORAGE_KEYS.warehouse) || "[]")
       existingWarehouse.push(warehouseData)
-      localStorage.setItem("shift_warehouse", JSON.stringify(existingWarehouse))
+      localStorage.setItem(SHIFT_STORAGE_KEYS.warehouse, JSON.stringify(existingWarehouse))
 
       if (!isConfigured) {
         toast({

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const SHIFT_STORAGE_KEYS = {
+  operations: "shift_operations",
+  qc: "shift_qc",
+  warehouse: "shift_warehouse",
+  cutting: "shift_cutting",
+} as const
+
+export type ShiftStorageKey = (typeof SHIFT_STORAGE_KEYS)[keyof typeof SHIFT_STORAGE_KEYS]


### PR DESCRIPTION
## Summary
- add shared `SHIFT_STORAGE_KEYS` constants for shift-related localStorage keys
- update shift, operations, cutting, QC, and warehouse sections to rely on the shared keys
- align the history view with the new constants for consistent access

## Testing
- pnpm lint *(fails: requires interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c93015072c8329a464f8290c653aba